### PR TITLE
Uninitialized variables were causing on macOS Catalina

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ scp02Test
 *.dir
 Win32
 *.manifest
+*.dylib
+

--- a/gppcscconnectionplugin/src/gppcscconnectionplugin.c
+++ b/gppcscconnectionplugin/src/gppcscconnectionplugin.c
@@ -80,7 +80,8 @@
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code  and error message are contained in the OPGP_ERROR_STATUS struct
 */
 OPGP_ERROR_STATUS OPGP_PL_establish_context(OPGP_CARD_CONTEXT *cardContext) {
-	OPGP_ERROR_STATUS status = {0};
+	OPGP_ERROR_STATUS status;
+	memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
 	LONG result = SCARD_S_SUCCESS;
 	OPGP_LOG_START(_T("OPGP_PL_establish_context"));
 	cardContext->librarySpecific = malloc(sizeof(PCSC_CARD_CONTEXT_SPECIFIC));
@@ -104,7 +105,8 @@ end:
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code  and error message are contained in the OPGP_ERROR_STATUS struct
 */
 OPGP_ERROR_STATUS OPGP_PL_release_context(OPGP_CARD_CONTEXT *cardContext) {
-	OPGP_ERROR_STATUS status = {0};
+    OPGP_ERROR_STATUS status;
+    memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
 	LONG result = SCARD_S_SUCCESS;
 	OPGP_LOG_START(_T("OPGP_PL_release_context"));
 	CHECK_CARD_CONTEXT_INITIALIZATION((*cardContext), status)
@@ -130,7 +132,8 @@ end:
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code and error message are contained in the OPGP_ERROR_STATUS struct
 */
 OPGP_ERROR_STATUS OPGP_PL_list_readers(OPGP_CARD_CONTEXT cardContext, OPGP_STRING readerNames, PDWORD readerNamesLength) {
-	OPGP_ERROR_STATUS status = {0};
+    OPGP_ERROR_STATUS status;
+    memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
 	LONG result = SCARD_S_SUCCESS;
 	DWORD readersSize = 0;
 	OPGP_STRING readers = NULL;
@@ -188,15 +191,18 @@ end:
 */
 OPGP_ERROR_STATUS OPGP_PL_card_connect(OPGP_CARD_CONTEXT cardContext, OPGP_CSTRING readerName, OPGP_CARD_INFO *cardInfo,
 	DWORD protocol) {
-		OPGP_ERROR_STATUS status = {0};
+        OPGP_ERROR_STATUS status;
+        memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
 		LONG result = SCARD_S_SUCCESS;
 		PCSC_CARD_INFO_SPECIFIC *pcscCardInfo = NULL;
 		DWORD activeProtocol = 0;
 		DWORD state = 0;
 		DWORD dummy = 0;
-		BYTE ATR[MAX_ATR_SIZE] = {0};
+		BYTE ATR[MAX_ATR_SIZE];
+		memset(ATR, 0, sizeof(ATR));
 		DWORD ATRLength=MAX_ATR_SIZE;
-		TCHAR readerNameTemp[1024] = {0};
+		TCHAR readerNameTemp[1024];
+		memset(readerNameTemp, 0, sizeof(readerNameTemp));
 		DWORD readerNameTempLength = 1024;
 
 		OPGP_LOG_START(_T("OPGP_PL_card_connect"));
@@ -254,7 +260,8 @@ end:
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code  and error message are contained in the OPGP_ERROR_STATUS struct.
 */
 OPGP_ERROR_STATUS OPGP_PL_card_disconnect(OPGP_CARD_CONTEXT cardContext, OPGP_CARD_INFO *cardInfo) {
-	OPGP_ERROR_STATUS status = {0};
+    OPGP_ERROR_STATUS status;
+    memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
 	LONG result = SCARD_S_SUCCESS;
 	OPGP_LOG_START(_T("OPGP_PL_card_disconnect"));
 	CHECK_CARD_CONTEXT_INITIALIZATION(cardContext, status)
@@ -283,7 +290,8 @@ end:
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code  and error message are contained in the OPGP_ERROR_STATUS struct.
 */
 OPGP_ERROR_STATUS OPGP_PL_send_APDU(OPGP_CARD_CONTEXT cardContext, OPGP_CARD_INFO cardInfo, PBYTE capdu, DWORD capduLength, PBYTE rapdu, PDWORD rapduLength) {
-	OPGP_ERROR_STATUS status;
+    OPGP_ERROR_STATUS status;
+    memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
 	// modified for managing all 4 cases with automatic APDU chaining
 
 	DWORD result = SCARD_S_SUCCESS;

--- a/gppcscconnectionplugin/src/gppcscconnectionplugin.c
+++ b/gppcscconnectionplugin/src/gppcscconnectionplugin.c
@@ -105,8 +105,8 @@ end:
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code  and error message are contained in the OPGP_ERROR_STATUS struct
 */
 OPGP_ERROR_STATUS OPGP_PL_release_context(OPGP_CARD_CONTEXT *cardContext) {
-    OPGP_ERROR_STATUS status;
-    memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
+	OPGP_ERROR_STATUS status;
+	memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
 	LONG result = SCARD_S_SUCCESS;
 	OPGP_LOG_START(_T("OPGP_PL_release_context"));
 	CHECK_CARD_CONTEXT_INITIALIZATION((*cardContext), status)
@@ -132,8 +132,8 @@ end:
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code and error message are contained in the OPGP_ERROR_STATUS struct
 */
 OPGP_ERROR_STATUS OPGP_PL_list_readers(OPGP_CARD_CONTEXT cardContext, OPGP_STRING readerNames, PDWORD readerNamesLength) {
-    OPGP_ERROR_STATUS status;
-    memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
+	OPGP_ERROR_STATUS status;
+	memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
 	LONG result = SCARD_S_SUCCESS;
 	DWORD readersSize = 0;
 	OPGP_STRING readers = NULL;
@@ -191,8 +191,8 @@ end:
 */
 OPGP_ERROR_STATUS OPGP_PL_card_connect(OPGP_CARD_CONTEXT cardContext, OPGP_CSTRING readerName, OPGP_CARD_INFO *cardInfo,
 	DWORD protocol) {
-        OPGP_ERROR_STATUS status;
-        memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
+		OPGP_ERROR_STATUS status;
+		memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
 		LONG result = SCARD_S_SUCCESS;
 		PCSC_CARD_INFO_SPECIFIC *pcscCardInfo = NULL;
 		DWORD activeProtocol = 0;
@@ -260,8 +260,8 @@ end:
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code  and error message are contained in the OPGP_ERROR_STATUS struct.
 */
 OPGP_ERROR_STATUS OPGP_PL_card_disconnect(OPGP_CARD_CONTEXT cardContext, OPGP_CARD_INFO *cardInfo) {
-    OPGP_ERROR_STATUS status;
-    memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
+	OPGP_ERROR_STATUS status;
+	memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
 	LONG result = SCARD_S_SUCCESS;
 	OPGP_LOG_START(_T("OPGP_PL_card_disconnect"));
 	CHECK_CARD_CONTEXT_INITIALIZATION(cardContext, status)
@@ -290,8 +290,8 @@ end:
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code  and error message are contained in the OPGP_ERROR_STATUS struct.
 */
 OPGP_ERROR_STATUS OPGP_PL_send_APDU(OPGP_CARD_CONTEXT cardContext, OPGP_CARD_INFO cardInfo, PBYTE capdu, DWORD capduLength, PBYTE rapdu, PDWORD rapduLength) {
-    OPGP_ERROR_STATUS status;
-    memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
+	OPGP_ERROR_STATUS status;
+	memset(&status, 0, sizeof(OPGP_ERROR_STATUS));
 	// modified for managing all 4 cases with automatic APDU chaining
 
 	DWORD result = SCARD_S_SUCCESS;

--- a/gppcscconnectionplugin/src/gppcscconnectionplugin.c
+++ b/gppcscconnectionplugin/src/gppcscconnectionplugin.c
@@ -80,8 +80,8 @@
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code  and error message are contained in the OPGP_ERROR_STATUS struct
 */
 OPGP_ERROR_STATUS OPGP_PL_establish_context(OPGP_CARD_CONTEXT *cardContext) {
-	OPGP_ERROR_STATUS status;
-	LONG result;
+	OPGP_ERROR_STATUS status = {0};
+	LONG result = SCARD_S_SUCCESS;
 	OPGP_LOG_START(_T("OPGP_PL_establish_context"));
 	cardContext->librarySpecific = malloc(sizeof(PCSC_CARD_CONTEXT_SPECIFIC));
 	if (cardContext->librarySpecific == NULL) {
@@ -104,8 +104,8 @@ end:
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code  and error message are contained in the OPGP_ERROR_STATUS struct
 */
 OPGP_ERROR_STATUS OPGP_PL_release_context(OPGP_CARD_CONTEXT *cardContext) {
-	OPGP_ERROR_STATUS status;
-	LONG result;
+	OPGP_ERROR_STATUS status = {0};
+	LONG result = SCARD_S_SUCCESS;
 	OPGP_LOG_START(_T("OPGP_PL_release_context"));
 	CHECK_CARD_CONTEXT_INITIALIZATION((*cardContext), status)
 		result = SCardReleaseContext(GET_SCARDCONTEXT((*cardContext)));
@@ -130,7 +130,7 @@ end:
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code and error message are contained in the OPGP_ERROR_STATUS struct
 */
 OPGP_ERROR_STATUS OPGP_PL_list_readers(OPGP_CARD_CONTEXT cardContext, OPGP_STRING readerNames, PDWORD readerNamesLength) {
-	OPGP_ERROR_STATUS status;
+	OPGP_ERROR_STATUS status = {0};
 	LONG result = SCARD_S_SUCCESS;
 	DWORD readersSize = 0;
 	OPGP_STRING readers = NULL;
@@ -188,15 +188,15 @@ end:
 */
 OPGP_ERROR_STATUS OPGP_PL_card_connect(OPGP_CARD_CONTEXT cardContext, OPGP_CSTRING readerName, OPGP_CARD_INFO *cardInfo,
 	DWORD protocol) {
-		OPGP_ERROR_STATUS status;
+		OPGP_ERROR_STATUS status = {0};
 		LONG result = SCARD_S_SUCCESS;
-		PCSC_CARD_INFO_SPECIFIC *pcscCardInfo;
-		DWORD activeProtocol;
-		DWORD state;
-		DWORD dummy;
-		BYTE ATR[MAX_ATR_SIZE];
+		PCSC_CARD_INFO_SPECIFIC *pcscCardInfo = NULL;
+		DWORD activeProtocol = 0;
+		DWORD state = 0;
+		DWORD dummy = 0;
+		BYTE ATR[MAX_ATR_SIZE] = {0};
 		DWORD ATRLength=MAX_ATR_SIZE;
-		TCHAR readerNameTemp[1024];
+		TCHAR readerNameTemp[1024] = {0};
 		DWORD readerNameTempLength = 1024;
 
 		OPGP_LOG_START(_T("OPGP_PL_card_connect"));
@@ -254,8 +254,8 @@ end:
 * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code  and error message are contained in the OPGP_ERROR_STATUS struct.
 */
 OPGP_ERROR_STATUS OPGP_PL_card_disconnect(OPGP_CARD_CONTEXT cardContext, OPGP_CARD_INFO *cardInfo) {
-	OPGP_ERROR_STATUS status;
-	LONG result;
+	OPGP_ERROR_STATUS status = {0};
+	LONG result = SCARD_S_SUCCESS;
 	OPGP_LOG_START(_T("OPGP_PL_card_disconnect"));
 	CHECK_CARD_CONTEXT_INITIALIZATION(cardContext, status)
 		CHECK_CARD_INFO_INITIALIZATION((*cardInfo), status)
@@ -286,11 +286,11 @@ OPGP_ERROR_STATUS OPGP_PL_send_APDU(OPGP_CARD_CONTEXT cardContext, OPGP_CARD_INF
 	OPGP_ERROR_STATUS status;
 	// modified for managing all 4 cases with automatic APDU chaining
 
-	DWORD result;
-	BYTE caseAPDU;
-	BYTE lc;
-	BYTE le=0;
-	BYTE la;
+	DWORD result = SCARD_S_SUCCESS;
+	BYTE caseAPDU = 0;
+	BYTE lc = 0;
+	BYTE le = 0;
+	BYTE la = 0;
 
 	DWORD offset = 0;
 


### PR DESCRIPTION
This took me quite a while to figure out.  What I was seeing was that when I called `OPGP_list_readers` prior to calling `OPGP_card_connect` the variable `dummy` at line 196 of `gppcscconnectionplugin/src/gppcscconnectionplugin.c` was being populated with some very large invalid number which was then causing `SCardStatus` to fail with `0x8010000F, Card protocol mismatch`.  Initialing `dummy` to 0 fixed the issue.  I then initialized all variables in the file.

Note:  I was calling into the code from a Go app.  No idea if that had anything to do with it.

macOS Catalina version 10.15.7
go version go1.15.3 darwin/amd64