### PR TITLE
Increasing max receive apdu length to 64K

### DIFF
--- a/gpshell/src/gpshell.c
+++ b/gpshell/src/gpshell.c
@@ -59,7 +59,6 @@
 #define PLATFORM_MODE_GP_211 GP_211
 #define PASSPHRASELEN 64
 #define AUTOREADER -1
-#define MAX_RECV_BUFFER_LEN 65536
 
 #define CHECK_TOKEN(token, option) token = parseToken(NULL);\
 if (token == NULL)\
@@ -1303,8 +1302,8 @@ static int handleCommands(FILE *fd)
             else if (_tcscmp(token, _T("get_data")) == 0)
             {
                 // Get Data
-                BYTE data[MAX_RECV_BUFFER_LEN];
-                DWORD dataLen = MAX_RECV_BUFFER_LEN;
+                BYTE data[256];
+                DWORD dataLen = 256;
                 DWORD i=0;
                 rv = handleOptions(&optionStr);
                 if (rv != EXIT_SUCCESS)
@@ -2031,8 +2030,8 @@ static int handleCommands(FILE *fd)
             }
             else if (_tcscmp(token, _T("send_apdu")) == 0 || _tcscmp(token, _T("send_apdu_nostop")) == 0)
             {
-                BYTE recvAPDU[MAX_RECV_BUFFER_LEN];
-                DWORD recvAPDULen = MAX_RECV_BUFFER_LEN;
+                DWORD recvAPDULen = 65536;
+                BYTE recvAPDU[recvAPDULen];
                 // Install for Load
                 rv = handleOptions(&optionStr);
                 if (rv != EXIT_SUCCESS)

--- a/gpshell/src/gpshell.c
+++ b/gpshell/src/gpshell.c
@@ -59,6 +59,7 @@
 #define PLATFORM_MODE_GP_211 GP_211
 #define PASSPHRASELEN 64
 #define AUTOREADER -1
+#define MAX_RECV_BUFFER_LEN 65536
 
 #define CHECK_TOKEN(token, option) token = parseToken(NULL);\
 if (token == NULL)\
@@ -1302,8 +1303,8 @@ static int handleCommands(FILE *fd)
             else if (_tcscmp(token, _T("get_data")) == 0)
             {
                 // Get Data
-                BYTE data[256];
-                DWORD dataLen = 256;
+                BYTE data[MAX_RECV_BUFFER_LEN];
+                DWORD dataLen = MAX_RECV_BUFFER_LEN;
                 DWORD i=0;
                 rv = handleOptions(&optionStr);
                 if (rv != EXIT_SUCCESS)
@@ -2030,8 +2031,8 @@ static int handleCommands(FILE *fd)
             }
             else if (_tcscmp(token, _T("send_apdu")) == 0 || _tcscmp(token, _T("send_apdu_nostop")) == 0)
             {
-                BYTE recvAPDU[258];
-                DWORD recvAPDULen = 258;
+                BYTE recvAPDU[MAX_RECV_BUFFER_LEN];
+                DWORD recvAPDULen = MAX_RECV_BUFFER_LEN;
                 // Install for Load
                 rv = handleOptions(&optionStr);
                 if (rv != EXIT_SUCCESS)


### PR DESCRIPTION
Increases the max received APDU length for send_apdu and get_data to 64k. This addresses the issue where PCSC (at least on a Mac) was seg faulting when the response consists of chained APDUs