### PR TITLE
Making the GPShell install_for_install command call the correct globalplatform API

### DIFF
--- a/gpshell/src/gpshell.1.md
+++ b/gpshell/src/gpshell.1.md
@@ -107,6 +107,13 @@ __install_for_install__ -priv *privilege* -AID *AIDInPkg* -pkgAID *pkgAID* -inst
 
 This command may be needed if the combined install command does not work. Or you want to install a pre-installed Security Domain.
 
+__install_for_make_selectable__ -priv *privilege* -instAID *instanceAID*
+
+:     Makes an installed applet instance selectable
+
+This command may be needed if the combined install command does not work. Typically this is used after an *install_for_install* 
+followed by personalization.
+
 __card_disconnect__
 
 :    Disconnect card

--- a/gpshell/src/gpshell.c
+++ b/gpshell/src/gpshell.c
@@ -1742,7 +1742,7 @@ static int handleCommands(FILE *fd)
                 if (platform_mode == PLATFORM_MODE_OP_201)
                 {
                     OP201_RECEIPT_DATA receipt;
-                    status = OP201_install_for_install_and_make_selectable(
+                    status = OP201_install_for_install(
                              cardContext, cardInfo, &securityInfo201,
                              (PBYTE)optionStr.pkgAID, optionStr.pkgAIDLen,
                              (PBYTE)optionStr.AID, optionStr.AIDLen,
@@ -1760,7 +1760,7 @@ static int handleCommands(FILE *fd)
                 {
                     GP211_RECEIPT_DATA receipt;
 
-                    status = GP211_install_for_install_and_make_selectable(
+                    status = GP211_install_for_install(
                              cardContext, cardInfo, &securityInfo211,
                              (PBYTE)optionStr.pkgAID, optionStr.pkgAIDLen,
                              (PBYTE)optionStr.AID, optionStr.AIDLen,
@@ -1777,7 +1777,7 @@ static int handleCommands(FILE *fd)
 
                 if (OPGP_ERROR_CHECK(status))
                 {
-                    _tprintf (_T("install_for_install_and_make_selectable() returns 0x%08X (%s)\n"),
+                    _tprintf (_T("install_for_install() returns 0x%08X (%s)\n"),
                               (unsigned int)status.errorCode, status.errorMessage);
                     rv = EXIT_FAILURE;
                     goto end;

--- a/gpshell/src/gpshell.c
+++ b/gpshell/src/gpshell.c
@@ -2139,6 +2139,48 @@ static int handleCommands(FILE *fd)
                     _tprintf("# %s\n", &commandLine[contentStart]);
                 }
             }
+            else if (_tcscmp(token, _T("install_for_make_selectable")) == 0)
+            {
+              DWORD receiptDataAvailable = 0;
+              // Install for Install
+              rv = handleOptions(&optionStr);
+              if (rv != EXIT_SUCCESS)
+              {
+                goto end;
+              }
+              if (platform_mode == PLATFORM_MODE_OP_201)
+              {
+                OP201_RECEIPT_DATA receipt;
+                status = OP201_install_for_make_selectable(
+                    cardContext, cardInfo, &securityInfo201,
+                    (PBYTE)optionStr.instAID, optionStr.instAIDLen,
+                    optionStr.privilege,
+                    NULL, // No install token
+                    &receipt,
+                    &receiptDataAvailable);
+              }
+              else if (platform_mode == PLATFORM_MODE_GP_211)
+              {
+                GP211_RECEIPT_DATA receipt;
+                status = GP211_install_for_make_selectable(
+                    cardContext, cardInfo, &securityInfo211,
+                    (PBYTE)optionStr.instAID, optionStr.instAIDLen,
+                    optionStr.privilege,
+                    NULL, // No install token
+                    &receipt,
+                    &receiptDataAvailable);
+              }
+
+              if (OPGP_ERROR_CHECK(status))
+              {
+                _tprintf (_T("install_for_make_selectable() returns 0x%08X (%s)\n"),
+                          (unsigned int)status.errorCode, status.errorMessage);
+                rv = EXIT_FAILURE;
+                goto end;
+              }
+              goto timer;
+
+            }
             else
             {
                 _tprintf(_T("Unknown command %s\n"), token);


### PR DESCRIPTION
Making install_for_install call xP2x1_install_for_install and not xP2x1_install_for_install_and_make_selectable