### PR TITLE
Use defined constant for receive APDU length

### DIFF
--- a/gpshell/src/gpshell.c
+++ b/gpshell/src/gpshell.c
@@ -59,6 +59,7 @@
 #define PLATFORM_MODE_GP_211 GP_211
 #define PASSPHRASELEN 64
 #define AUTOREADER -1
+#define MAX_RECEIVE_BUFFER_LEN 65536
 
 #define CHECK_TOKEN(token, option) token = parseToken(NULL);\
 if (token == NULL)\
@@ -2030,8 +2031,8 @@ static int handleCommands(FILE *fd)
             }
             else if (_tcscmp(token, _T("send_apdu")) == 0 || _tcscmp(token, _T("send_apdu_nostop")) == 0)
             {
-                DWORD recvAPDULen = 65536;
-                BYTE recvAPDU[recvAPDULen];
+                DWORD recvAPDULen = MAX_RECEIVE_BUFFER_LEN;
+                BYTE recvAPDU[MAX_RECEIVE_BUFFER_LEN];
                 // Install for Load
                 rv = handleOptions(&optionStr);
                 if (rv != EXIT_SUCCESS)


### PR DESCRIPTION
Visual Studio generates an error when using a variable to set the
length of an array.  GCC allows this, but it is not part of the C
standard.  Hence, use a constant expression to set both the initial
recveAPDULen and recvAPDU array length.