### PR TITLE
fix key data for put key for AES key type

### DIFF
--- a/globalplatform/src/crypto.c
+++ b/globalplatform/src/crypto.c
@@ -1361,6 +1361,7 @@ end:
   * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code  and error message are contained in the OPGP_ERROR_STATUS struct
  */
 OPGP_ERROR_STATUS calculate_key_check_value(GP211_SECURITY_INFO *secInfo,
+	BYTE keyType,
 	PBYTE keyData,
 	DWORD keyDataLength,
 	BYTE keyCheckValue[3]) {
@@ -1370,7 +1371,7 @@ OPGP_ERROR_STATUS calculate_key_check_value(GP211_SECURITY_INFO *secInfo,
 	BYTE keyCheckTest[16];
 	OPGP_LOG_START(_T("calculate_key_check_value"));
 	memset(keyCheckTest, 0, 16);
-	if (secInfo->secureChannelProtocol == GP211_SCP03) {
+	if (secInfo->secureChannelProtocol == GP211_SCP03 || keyType == GP211_KEY_TYPE_AES) {
 		memset(keyCheckTest, 0x01, sizeof(keyCheckTest));
 		status = calculate_enc_ecb_SCP03(keyData, keyDataLength, keyCheckTest, 16, dummy, &dummyLength);
 	}
@@ -1443,7 +1444,7 @@ OPGP_ERROR_STATUS get_key_data_field(GP211_SECURITY_INFO *secInfo,
 	}
 	// we always use key check values
 	keyDataField[i++] = 0x03; // length of key check value
-	status = calculate_key_check_value(secInfo, keyData, keyDataLength, keyCheckValue);
+	status = calculate_key_check_value(secInfo, keyType, keyData, keyDataLength, keyCheckValue);
 	if (OPGP_ERROR_CHECK(status)) {
 		goto end;
 	}
@@ -2027,7 +2028,6 @@ OPGP_ERROR_STATUS read_public_rsa_key(OPGP_STRING PEMKeyFileName, char *passPhra
     OSSL_PARAM *params;
     OSSL_PARAM *_n;
 	OSSL_PARAM *_e;
-	int i;
 #endif
 	OPGP_LOG_START(_T("read_public_rsa_key"));
 	if (passPhrase == NULL)

--- a/globalplatform/src/crypto.c
+++ b/globalplatform/src/crypto.c
@@ -1404,7 +1404,7 @@ OPGP_ERROR_STATUS get_key_data_field(GP211_SECURITY_INFO *secInfo,
 	memset(keyCheckTest, 0, 16);
 	// key type + length + key data + length + key check value
 	sizeNeeded = 1 + 1 + keyDataLength + 1;
-	if (secInfo->secureChannelProtocol == GP211_SCP03) {
+	if (secInfo->secureChannelProtocol == GP211_SCP03 || keyType == GP211_KEY_TYPE_AES) {
 		// the length of the key component is always included
 		sizeNeeded++;
 	}

--- a/globalplatform/src/crypto.c
+++ b/globalplatform/src/crypto.c
@@ -1424,7 +1424,7 @@ OPGP_ERROR_STATUS get_key_data_field(GP211_SECURITY_INFO *secInfo,
 		if (OPGP_ERROR_CHECK(status)) {
 			goto end;
 		}
-		if (encrypted_key_length != keyDataLength || secInfo->secureChannelProtocol == GP211_SCP03) {
+		if (encrypted_key_length != keyDataLength || secInfo->secureChannelProtocol == GP211_SCP03 || keyType == GP211_KEY_TYPE_AES) {
 			// + 1 byte key component length field
 			keyDataField[i++] = encrypted_key_length + 1;
 			keyDataField[i++] = keyDataLength;

--- a/globalplatform/src/crypto.h
+++ b/globalplatform/src/crypto.h
@@ -47,6 +47,7 @@ OPGP_ERROR_STATUS calculate_CMAC_aes(BYTE sMacKey[32], DWORD keyLength, BYTE *me
 
 OPGP_NO_API
 OPGP_ERROR_STATUS calculate_key_check_value(GP211_SECURITY_INFO *secInfo,
+	BYTE keyType,
 	PBYTE keyData,
 	DWORD keyDataLength,
 	BYTE keyCheckValue[3]);

--- a/globalplatform/src/globalplatform.c
+++ b/globalplatform/src/globalplatform.c
@@ -6777,9 +6777,24 @@ OPGP_ERROR_STATUS OPGP_calculate_key_check_value(GP211_SECURITY_INFO *secInfo,
 	PBYTE keyData,
 	DWORD keyDataLength,
 	BYTE keyCheckValue[3]) {
+	return OPGP_calculate_key_check_value_with_key_type(secInfo, 0, keyData, keyDataLength, keyCheckValue);
+}
+
+/**
+ * \param *secInfo [in, out] The pointer to the GP211_SECURITY_INFO structure returned by GP211_mutual_authentication().
+ * \param keyData [in] The key data.
+ * \param keyDataLength [in] The key data length.
+ * \param keyCheckValue [out] The key check value.
+  * \return OPGP_ERROR_STATUS struct with error status OPGP_ERROR_STATUS_SUCCESS if no error occurs, otherwise error code  and error message are contained in the OPGP_ERROR_STATUS struct
+ */
+OPGP_ERROR_STATUS OPGP_calculate_key_check_value_with_key_type(GP211_SECURITY_INFO *secInfo,
+	BYTE keyType,
+	PBYTE keyData,
+	DWORD keyDataLength,
+	BYTE keyCheckValue[3]) {
 	OPGP_ERROR_STATUS status;
 	OPGP_LOG_START(_T("OPGP_calculate_key_check_value"));
-	status = calculate_key_check_value(secInfo, keyData, keyDataLength, keyCheckValue);
+	status = calculate_key_check_value(secInfo, keyType, keyData, keyDataLength, keyCheckValue);
 	if (OPGP_ERROR_CHECK(status)) {
 		goto end;
 	}

--- a/globalplatform/src/globalplatform/globalplatform.h
+++ b/globalplatform/src/globalplatform/globalplatform.h
@@ -770,6 +770,10 @@ OPGP_ERROR_STATUS OPGP_select_channel(OPGP_CARD_INFO *cardInfo, BYTE channelNumb
 OPGP_ERROR_STATUS OPGP_calculate_key_check_value(GP211_SECURITY_INFO *secInfo,
 	PBYTE keyData, DWORD keyDataLength, BYTE keyCheckValue[3]);
 
+//! \brief Calculates the key check value of a key.
+OPGP_ERROR_STATUS OPGP_calculate_key_check_value_with_key_type(GP211_SECURITY_INFO *secInfo,
+	BYTE keyType, PBYTE keyData, DWORD keyDataLength, BYTE keyCheckValue[3]);
+
 //! \brief Encrypts sensitive data like keys or other data which is used in STORE DATA.
 OPGP_ERROR_STATUS OPGP_encrypt_sensitive_data(GP211_SECURITY_INFO *secInfo,
 	PBYTE data, DWORD dataLength,

--- a/globalplatform/src/globalplatform/globalplatform.h
+++ b/globalplatform/src/globalplatform/globalplatform.h
@@ -511,6 +511,12 @@ OPGP_ERROR_STATUS GP211_put_secure_channel_keys(OPGP_CARD_CONTEXT cardContext, O
 							 BYTE keySetVersion, BYTE newKeySetVersion, BYTE baseKey[32],
 							 BYTE newS_ENC[32], BYTE newS_MAC[32], BYTE newDEK[32], DWORD keyLength);
 
+//! \brief GlobalPlatform2.1.1: replaces or adds a secure channel key set consisting of S-ENC, S-MAC and DEK.
+OPGP_API
+OPGP_ERROR_STATUS GP211_put_secure_channel_keys_with_key_type(OPGP_CARD_CONTEXT cardContext, OPGP_CARD_INFO cardInfo, GP211_SECURITY_INFO *secInfo,
+							 BYTE keySetVersion, BYTE newKeySetVersion, BYTE baseKey[32],
+							 BYTE newS_ENC[32], BYTE newS_MAC[32], BYTE newDEK[32], DWORD keyLength, BYTE keyType);
+
 //! \brief GlobalPlatform2.1.1: deletes a key or multiple keys.
 OPGP_API
 OPGP_ERROR_STATUS GP211_delete_key(OPGP_CARD_CONTEXT cardContext, OPGP_CARD_INFO cardInfo, GP211_SECURITY_INFO *secInfo,

--- a/gpshell/src/gpshell.1.md
+++ b/gpshell/src/gpshell.1.md
@@ -385,6 +385,10 @@ __-noStop__
 
 :    Does not stop in case of an error
 
+__-keyType__ *keyType*
+
+:    Type of the key for the put_sc_key command. Must be in hex format, e.g. 88.
+
 ## Format of CPLC data
 
 You see the command trace of a GET DATA command and the interpreted result.


### PR DESCRIPTION
please modify line 1427 --> || keyType == GP211_KEY_TYPE_AES
```
if (encrypted_key_length != keyDataLength || secInfo->secureChannelProtocol == GP211_SCP03 || keyType == GP211_KEY_TYPE_AES) {
			// + 1 byte key component length field
			keyDataField[i++] = encrypted_key_length + 1;
			keyDataField[i++] = keyDataLength;
		}
```