### PR TITLE
gpshell: dlopen gppcscconnectionplugin.so.1.

### DIFF
--- a/gpshell/src/gpshell.c
+++ b/gpshell/src/gpshell.c
@@ -1028,6 +1028,8 @@ static int handleCommands(FILE *fd)
                 // Establish context
                 _tcsncpy(cardContext.libraryName, _T("gppcscconnectionplugin"),
                          _tcslen(_T("gppcscconnectionplugin"))+1);
+                _tcsncpy(cardContext.libraryVersion, _T("1"),
+                         _tcslen(_T("1"))+1);
                 status = OPGP_establish_context(&cardContext);
                 if (OPGP_ERROR_CHECK(status))
                 {


### PR DESCRIPTION
The rationale is that on most normal systems, there is no gppcscconnectionplugin.so symlink but only a gppcscconnectionplugin.so.1.  The .so symlink is only on developer systems.  It may look strange to hard-code the shared library version here, but we already hard code the shared library name.  What do you think?