### PR TITLE
gpshell.1.md: fix version number

### DIFF
--- a/gpshell/src/gpshell.1.md
+++ b/gpshell/src/gpshell.1.md
@@ -1,4 +1,4 @@
-% GPSHELL(1) 2.2.0 | GPShell Documentation
+% GPSHELL(1) 2.4.0 | GPShell Documentation
 
 # NAME
 


### PR DESCRIPTION
Version 2.4.0 is the latest release, not 2.2.0.